### PR TITLE
move pg-client install to docker image

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,0 +1,7 @@
+FROM circleci/ruby:2.5.1-stretch-node-browsers
+
+RUN sudo apt-get install curl ca-certificates gnupg
+RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null
+RUN sudo bash -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" >> /etc/apt/sources.list.d/pgdg.list'
+RUN sudo apt-get update
+RUN sudo apt-get -y --allow-unauthenticated install postgresql-client-9.5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     parallelism: 2
     working_directory: ~/circleci-test
     docker:
-      - image: circleci/ruby:2.5.1-stretch-node-browsers
+      - image: madmatvey/ruby_with_pg_client:ruby2.5.1-pg9.5
         environment:
           PGHOST: 127.0.0.1
           PGUSER: postgres
@@ -17,19 +17,6 @@ jobs:
       - image: redis
     steps:
       - checkout
-      - run: sudo apt-get install curl ca-certificates gnupg && sudo update-ca-certificates
-      - run: curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null 
-      - run: sudo bash -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" >> /etc/apt/sources.list.d/pgdg.list'
-      - run: sudo apt-get update
-      # - run: sudo apt-get -y --allow-unauthenticated install postgresql-client-12
-      # - run: |
-      #     echo "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main" | sudo tee -a /etc/apt/sources.list \
-      #     && wget -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add ACCC4CF8.asc \
-      #     && sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F76221572C52609D 749D6EEC0353B12C
-
-      # Install System Dependencies
-      - run: sudo apt-get update -qq && sudo apt-get install -y build-essential postgresql-client-9.5
-
       # Restore bundle cache
       - type: cache-restore
         name: Restore bundle cache
@@ -84,4 +71,3 @@ jobs:
       # Save artifacts
       - store_artifacts:
           path: tmp/capybara
-


### PR DESCRIPTION
### Суть подхода
- избавиться от установки клиента Postgres при каждом запуске CircleCI 
- найти способ сделать это один раз и завернуть это в docker образ 
- использовать этот docker образ для того чтобы разворачивать тестовое окружение

### Что сделали

собираем докер образ с уже установленным клиентом для Postgres нужной версии

```bash
cd .circleci
docker build  --no-cache -t ruby_pg_client . 
 => => writing image sha256:85c511a5f2f31a7c54c01ad6384b25a6d583d0048b91ec60562b375f05bcb25a                                                                                 
 => => naming to docker.io/library/ruby_pg_client
```

отмечаем собраный образ тегом
```bash
docker tag 85c511a5f2f31a7c54c01ad6384b25a6d583d0048b91ec60562b375f05bcb25a madmatvey/ruby_with_pg_client:ruby2.5.1-pg9.5
```
Пушим его в Docker Hub 
```bash
docker push madmatvey/ruby_with_pg_client:ruby2.5.1-pg9.5
``` 